### PR TITLE
fix invalid argument error

### DIFF
--- a/mule/luaenv.cpp
+++ b/mule/luaenv.cpp
@@ -256,7 +256,7 @@ int readTable(int fd, std::string handler)
 
         for (auto &&pair : titr->second)
         {
-            xybase::Stream *stream = new xybase::TextStream(Configuration::GetInstance().SheetsDir + pair.first + "." + handler, 1);
+            xybase::Stream *stream = new xybase::TextStream(Configuration::GetInstance().SheetsDir + pair.first + "." + handler, std::ios::out);
             proc->SetStream(stream);
             std::wcout << L"Processing " << xybase::string::to_wstring(pair.first) << std::endl;
             pair.second->Read(sitr->second, proc);


### PR DESCRIPTION
origin error: invalid conversion from ‘int’ to ‘std::ios_base::openmode’
signature: TextStream(std::string path, std::ios::openmode mode, std::string localeStr = {});
DOC: https://en.cppreference.com/w/cpp/io/ios_base/openmode